### PR TITLE
✅ 겹치는 건 싫어 

### DIFF
--- a/Kim Byeol/2023.08.30/겹치는 건 싫어(투포인터).java
+++ b/Kim Byeol/2023.08.30/겹치는 건 싫어(투포인터).java
@@ -12,30 +12,31 @@ public class Main {
 
         int[] arr = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
 
+
         Map<Integer, Integer> map = new HashMap<>();
 
-        int r = 0;
-        int l = 0;
+        int left = 0;
+        int right = 0;
 
         int cnt = 0;
         int max = Integer.MIN_VALUE;
 
-        while (l < N) {
-            if (!map.containsKey(arr[l]) || map.get(arr[l]) < K) {
-                map.put(arr[l], map.getOrDefault(arr[l], 0) + 1);
-                l++;
+        while (right < N) {
+            if (!map.containsKey(arr[right]) || map.get(arr[right]) < K) {
+                map.put(arr[right], map.getOrDefault(arr[right], 0) + 1);
+                right++;
                 cnt++;
                 max = max < cnt ? cnt : max;
                 continue;
             }
 
-            if (map.get(arr[l]) == K) {
-                int removal = arr[l];
-                while (r <= l) {
-                    map.put(arr[r], map.get(arr[r]) - 1);
-                    r++;
+            if (map.get(arr[right]) == K) {
+                int removal = arr[right];
+                while (left <= right) {
+                    map.put(arr[left], map.get(arr[left]) - 1);
+                    left++;
                     cnt--;
-                    if (arr[r - 1] == removal) break;
+                    if (arr[left - 1] == removal) break;
                 }
             }
 

--- a/Kim Byeol/2023.08.30/겹치는 건 싫어(투포인터).java
+++ b/Kim Byeol/2023.08.30/겹치는 건 싫어(투포인터).java
@@ -1,0 +1,47 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int[] inputs = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+
+        int N = inputs[0];
+        int K = inputs[1];
+
+        int[] arr = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+
+        Map<Integer, Integer> map = new HashMap<>();
+
+        int r = 0;
+        int l = 0;
+
+        int cnt = 0;
+        int max = Integer.MIN_VALUE;
+
+        while (l < N) {
+            if (!map.containsKey(arr[l]) || map.get(arr[l]) < K) {
+                map.put(arr[l], map.getOrDefault(arr[l], 0) + 1);
+                l++;
+                cnt++;
+                max = max < cnt ? cnt : max;
+                continue;
+            }
+
+            if (map.get(arr[l]) == K) {
+                int removal = arr[l];
+                while (r <= l) {
+                    map.put(arr[r], map.get(arr[r]) - 1);
+                    r++;
+                    cnt--;
+                    if (arr[r - 1] == removal) break;
+                }
+            }
+
+        }
+
+        System.out.println(max);
+    }
+
+}

--- a/Kim Byeol/2023.08.30/겹치는 건 싫어.md
+++ b/Kim Byeol/2023.08.30/겹치는 건 싫어.md
@@ -1,0 +1,33 @@
+## 접근
+><a href="https://www.acmicpc.net/problem/20922">겹치는 건 싫어</a>
+같은 원소가 K개 이하로 들어있는 최장 연속 부분 수열의 길이를 구하는 문제이다.
+
+## 풀이
+- Map을 이용하여 중복된 개수를 파악한다.
+- 투포인터 알고리즘을 이용하여 왼쪽 포인터가 문제에 주어진 array의 길이에 넘어가지 않도록 한다.
+  - 등장한 적 없거나 혹은 등장 했더라도 K개 이하라면 수열의 길이에 +1을 하며</br>
+    이전에 등장했던 연속 부분 수열의 길이보다 큰지 비교하며 갱신한다.</br>
+    또한 Map에 넣어주고 전진할 수 있으므로 왼쪽 포인터를 늘려준다.
+    ```java
+     while (right < N) {
+            if (!map.containsKey(arr[right]) || map.get(arr[right]) < K) {
+                map.put(arr[right], map.getOrDefault(arr[right], 0) + 1);
+                right++;
+                cnt++;
+                max = max < cnt ? cnt : max;
+                continue;
+            }
+    ```
+   - 그러나 이전에 등장해서 K개를 채운 경우에는 왼쪽을 이동시키며 Map에서 제거한다.</br>
+   이동하면서 제거하고자 하는 removal을 만나는 경우에 while문을 벗어난다.
+      ```java
+      if (map.get(arr[right]) == K) {
+                int removal = arr[right];
+                while (left <= right) {
+                    map.put(arr[left], map.get(arr[left]) - 1);
+                    left++;
+                    cnt--;
+                    if (arr[left - 1] == removal) break;
+                }
+          }
+      ```


### PR DESCRIPTION
## 접근
><a href="https://www.acmicpc.net/problem/20922">겹치는 건 싫어</a>
같은 원소가 K개 이하로 들어있는 최장 연속 부분 수열의 길이를 구하는 문제이다.

## 풀이
- Map을 이용하여 중복된 개수를 파악한다.
- 투포인터 알고리즘을 이용하여 왼쪽 포인터가 문제에 주어진 array의 길이에 넘어가지 않도록 한다.
  - 등장한 적 없거나 혹은 등장 했더라도 K개 이하라면 수열의 길이에 +1을 하며</br>
    이전에 등장했던 연속 부분 수열의 길이보다 큰지 비교하며 갱신한다.</br>
    또한 Map에 넣어주고 전진할 수 있으므로 왼쪽 포인터를 늘려준다.
    ```java
     while (right < N) {
            if (!map.containsKey(arr[right]) || map.get(arr[right]) < K) {
                map.put(arr[right], map.getOrDefault(arr[right], 0) + 1);
                right++;
                cnt++;
                max = max < cnt ? cnt : max;
                continue;
            }
    ```
   - 그러나 이전에 등장해서 K개를 채운 경우에는 왼쪽을 이동시키며 Map에서 제거한다.</br>
   이동하면서 제거하고자 하는 removal을 만나는 경우에 while문을 벗어난다.
      ```java
      if (map.get(arr[right]) == K) {
                int removal = arr[right];
                while (left <= right) {
                    map.put(arr[left], map.get(arr[left]) - 1);
                    left++;
                    cnt--;
                    if (arr[left - 1] == removal) break;
                }
          }
      ```
